### PR TITLE
Upgrade New JSX Transform

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,6 +25,12 @@ module.exports = (api) => {
             '@babel/typescript',
         ],
         plugins: [
+            [
+                '@babel/plugin-transform-react-jsx',
+                {
+                    runtime: 'automatic',
+                },
+            ],
             '@babel/proposal-object-rest-spread',
             '@babel/proposal-class-properties',
             '@babel/proposal-optional-chaining',


### PR DESCRIPTION
Can not config New JSX Transform correctly
## Description / What does this PR do?
After I upgrade react 16 to react 18. I try to add these config to set up New JSX Transform. But I got fail when run "yarn start"
.. So I can't load Chakra UI, (or bootstrap@5 + react-bootrap@2). Current, I have to use bootstrap@4 and react-bootstrap@1.

Can you give me an advisement to add New JSX Transform config correctly. Many thank